### PR TITLE
Title (and font properties) + frame removal

### DIFF
--- a/scTDA/main.py
+++ b/scTDA/main.py
@@ -1191,7 +1191,8 @@ class UnrootedGraph(object):
         return numpy.array(mat)
 
     def draw(self, color, connected=True, labels=False, ccmap='jet', weight=8.0, save='', ignore_log=False,
-             table=False, axis=[], a=0.4, dpi=None, figsize=None, lw=1.0, title=None, title_font='Arial'):
+             table=False, axis=[], a=0.4, dpi=None, figsize=None, lw=1.0, title=None,
+             font_props={'fontname': 'Arial'}):
         """
         Displays topological representation of the data colored according to the expression of a gene, genes or
         list of genes, specified by argument 'color'. This can be a gene or a list of one, two or three genes or lists
@@ -1338,7 +1339,7 @@ class UnrootedGraph(object):
                 the_table.scale(1.787, 1)
                 pylab.subplots_adjust(bottom=0.2)
         if title is not None:
-            plt.title(title, title_font)
+            plt.title(title, **font_props)
         if len(axis) == 4:
             pylab.axis(axis)
         if save == '':

--- a/scTDA/main.py
+++ b/scTDA/main.py
@@ -43,6 +43,11 @@ pylab.rcParams['patch.facecolor'] = 'k'
 GLOBAL METHODS
 """
 
+def _remove_frame(ax):
+    plt.setp(ax.spines.values(), linewidth=0)
+    ax.set_xticks([])
+    ax.set_yticks([])
+
 
 def ParseAyasdiGraph(name, source, lab, user, password):
     """
@@ -1192,7 +1197,7 @@ class UnrootedGraph(object):
 
     def draw(self, color, connected=True, labels=False, ccmap='jet', weight=8.0, save='', ignore_log=False,
              table=False, axis=[], a=0.4, dpi=None, figsize=None, lw=1.0, title=None,
-             font_props={'fontname': 'Arial'}):
+             font_props={'fontname': 'Arial'}, remove_frame=False):
         """
         Displays topological representation of the data colored according to the expression of a gene, genes or
         list of genes, specified by argument 'color'. This can be a gene or a list of one, two or three genes or lists
@@ -1340,6 +1345,8 @@ class UnrootedGraph(object):
                 pylab.subplots_adjust(bottom=0.2)
         if title is not None:
             plt.title(title, **font_props)
+        if remove_frame:
+            _remove_frame(plt.gca())
         if len(axis) == 4:
             pylab.axis(axis)
         if save == '':

--- a/scTDA/main.py
+++ b/scTDA/main.py
@@ -1191,7 +1191,7 @@ class UnrootedGraph(object):
         return numpy.array(mat)
 
     def draw(self, color, connected=True, labels=False, ccmap='jet', weight=8.0, save='', ignore_log=False,
-             table=False, axis=[], a=0.4, dpi=None, figsize=None, lw=1.0, title=None):
+             table=False, axis=[], a=0.4, dpi=None, figsize=None, lw=1.0, title=None, title_font='Arial'):
         """
         Displays topological representation of the data colored according to the expression of a gene, genes or
         list of genes, specified by argument 'color'. This can be a gene or a list of one, two or three genes or lists
@@ -1338,7 +1338,7 @@ class UnrootedGraph(object):
                 the_table.scale(1.787, 1)
                 pylab.subplots_adjust(bottom=0.2)
         if title is not None:
-            plt.title(title)
+            plt.title(title, title_font)
         if len(axis) == 4:
             pylab.axis(axis)
         if save == '':

--- a/scTDA/main.py
+++ b/scTDA/main.py
@@ -13,6 +13,7 @@ __credits__ = "Patrick van Nieuwenhuizen, Luis Aparicio, Yan Meng"
 
 import json
 import matplotlib_venn
+import matplotlib.pyplot as plt
 import networkx
 import numexpr
 import numpy
@@ -1190,7 +1191,7 @@ class UnrootedGraph(object):
         return numpy.array(mat)
 
     def draw(self, color, connected=True, labels=False, ccmap='jet', weight=8.0, save='', ignore_log=False,
-             table=False, axis=[], a=0.4, dpi=None, figsize=None, lw=1.0):
+             table=False, axis=[], a=0.4, dpi=None, figsize=None, lw=1.0, title=None):
         """
         Displays topological representation of the data colored according to the expression of a gene, genes or
         list of genes, specified by argument 'color'. This can be a gene or a list of one, two or three genes or lists
@@ -1336,6 +1337,8 @@ class UnrootedGraph(object):
                                         rowColours=['r', 'g', 'b'], colWidths=[0.08] * 7)
                 the_table.scale(1.787, 1)
                 pylab.subplots_adjust(bottom=0.2)
+        if title is not None:
+            plt.title(title)
         if len(axis) == 4:
             pylab.axis(axis)
         if save == '':


### PR DESCRIPTION
PR for `draw` method for additional figure aesthetics:
- Figure title and font properties
- Figure frame removal flag

Example code:
```
c.draw('Gran', ccmap='Reds', weight=2, dpi=200, figsize=(5,5), lw=1.0, title='Gran', font_props={'fontname': 'Arial'}, remove_frame=True)
```

Example figure:
![example](https://user-images.githubusercontent.com/697622/42539193-4e2257de-8468-11e8-9c7f-f066ff2ee982.png)
